### PR TITLE
FORD Compatibility

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ For more help, you can type
 ## Rules
 
 Here is a non-comprehensive set of rules that are enforced:
-  * Punctuation should be followed by a space, this include `,`, `;` and `)`.
+  * Punctuation should be followed by a space, this includes `,`, `;` and `)`.
   * Binary operators (`==`, `+`, ...) should be surrounded by spaces
   * The following special characters are surrounded by at least one space: `::`, `=`.
   * A line should not exceed 120 characters (this is somehow already extreme). The maximum line length can be controlled from the CLI.
@@ -48,6 +48,7 @@ Here is a non-comprehensive set of rules that are enforced:
   * `print` statements should look like `print *, "something"`
   * `write` statements should look like `write(*, *) "something"`
   * Lines should be indented consistently (by default, using an indentation of 4 spaces)
+  * [FORD](https://forddocs.readthedocs.io/en/latest/) Compatibility: `!!` and `!>` are preserved and treated as comments like `!` with one space after and at least one space before.
 
 # TODO list
 

--- a/fortran_linter/main.py
+++ b/fortran_linter/main.py
@@ -59,8 +59,11 @@ class FortranRules:
         (r"\t", "  ", "Should use 2 spaces instead of tabulation"),
         # Fix "foo! comment" to "foo ! comment"
         (r"(\w)(\!(?!\$)|\!\$)", r"\1 \2", "At least one space before comment"),
-        # Fix "!bar" to "! bar"
-        (r"\!(|\s\s+)(?!\$)(\S)", r"! \2", "Exactly one space after comment"),
+        # Enforce space after comments (but ignoring !$):
+        # # Fix "!bar" to "! bar" (Normal F90)
+        # (r"\!(|\s\s+)(?!\$)(\S)", r"! \2", "Exactly one space after comment"),
+        # Fix "<>bar" to "<> bar" where <> can be !, !!, !> (FORD Documentation)
+        (r"(![!>#]?(?:(?=[^\s!>#$]|(\s\s)|\s\$)|\$(?!\S)))\s*(.*)", r"\1 \3", "Exactly one space after comment"),
         # Remove trailing ";"
         (r";\s*$", r"\n", 'Useless ";" at end of line'),
         [

--- a/fortran_linter/main.py
+++ b/fortran_linter/main.py
@@ -60,10 +60,12 @@ class FortranRules:
         # Fix "foo! comment" to "foo ! comment"
         (r"(\w)(\!(?!\$)|\!\$)", r"\1 \2", "At least one space before comment"),
         # Enforce space after comments (but ignoring !$):
-        # # Fix "!bar" to "! bar" (Normal F90)
-        # (r"\!(|\s\s+)(?!\$)(\S)", r"! \2", "Exactly one space after comment"),
         # Fix "<>bar" to "<> bar" where <> can be !, !!, !> (FORD Documentation)
-        (r"(![!>#]?(?:(?=[^\s!>#$]|(\s\s)|\s\$)|\$(?!\S)))\s*(.*)", r"\1 \3", "Exactly one space after comment"),
+        (
+            r"(![!>#]?(?:(?=[^\s!>#$]|(\s\s)|\s\$)|\$(?!\S)))\s*(.*)",
+            r"\1 \3",
+            "Exactly one space after comment",
+        ),
         # Remove trailing ";"
         (r";\s*$", r"\n", 'Useless ";" at end of line'),
         [

--- a/tests/test.f90
+++ b/tests/test.f90
@@ -48,6 +48,10 @@ foo>=bar.and.bis>bas ! should have spaces around
 
 a = 2!bar            - missing spaces around '!'
 a = 2 !  bar         - too many spaces after '!'
+a = 2!!bar           - missing spaces around FORD '!!'
+a = 2!>bar           - missing spaces around FORD '!>'
+a = 2 !!   bar       - too many spaces after FORD '!!'
+a = 2 !>     bar     - too many spaces after FORD '!>'
 
 integer*4 :: foo     ! old syntax, should become integer(4)
 

--- a/tests/test_comment_detection.py
+++ b/tests/test_comment_detection.py
@@ -37,6 +37,12 @@ def test_fortran_comment_detection():
         ("! test", 0),
         ("    !test", 4),
         ("'Contains a string', ! and a comment", 21),
+        ("!! test", 0),
+        ("    !!test", 4),
+        ("'Contains a string', !! and a comment", 21),
+        ("!> test", 0),
+        ("    !>test", 4),
+        ("'Contains a string', !> and a comment", 21),
     )
 
     no_comment_lines = (

--- a/tests/test_reference.f90
+++ b/tests/test_reference.f90
@@ -48,6 +48,10 @@ bla          ! line started with a tab, should become spaces
 
 a = 2 ! bar            - missing spaces around '!'
 a = 2 ! bar         - too many spaces after '!'
+a = 2 !! bar           - missing spaces around FORD '!!'
+a = 2 !> bar           - missing spaces around FORD '!>'
+a = 2 !! bar       - too many spaces after FORD '!!'
+a = 2 !> bar     - too many spaces after FORD '!>'
 
 integer(4) :: foo     ! old syntax, should become integer(4)
 


### PR DESCRIPTION
Closes #86 

Hej,

After bashing my head against Regex for a while I have modified so that the linter will treat FORD markers as comments.

Initially I wanted to make a cli argument `--ford` to trigger this, and fall back on the currentl rule if not, but this was tricky in the `_rules` list so I just replaced with the assumption that an error where someone has typed `!!` or `!>` not intending to be used by FORD is unlikely, and even if they did it will still be treated as a comment.

I also added tests - please check that you are satisfied.