### PR TITLE
Match open/close statements and format them

### DIFF
--- a/fortran_linter/main.py
+++ b/fortran_linter/main.py
@@ -468,7 +468,7 @@ class Indenter:
             line = line[: span[0]] + proper_format + line[span[1] :]
 
         elif self.checker(
-            line,
+            line[:comment_pos],
             INDENTER_RULES,
             comment_pos,
             string_spans,


### PR DESCRIPTION
Closes #111.


Replaces
```fortran
module m
  implicit none
contains
  real function twice(x)
      real, intent(in) :: x
      twice = 2 * x
  end

  subroutine sub(x, y)
      implicit none
      real, intent(in) :: x
      real, intent(out) :: y
      y = 2 * x + 4.5
  end
end

program main
use m
implicit none
real :: x, y
x = 10.0
call sub(x, y)
print *, y
print *, twice(y)
end
```
with
```fortran
module m
    implicit none
contains
    real function twice(x)
        real, intent(in) :: x
        twice = 2 * x
    end function twice

    subroutine sub(x, y)
        implicit none
        real, intent(in) :: x
        real, intent(out) :: y
        y = 2 * x + 4.5
    end subroutine sub
end module m

program main
    use m
    implicit none
    real :: x, y
    x = 10.0
    call sub(x, y)
    print *, y
    print *, twice(y)
end program main
```